### PR TITLE
Fix download link

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -62,6 +62,7 @@ my $builder = Alien::Base::ModuleBuild->new(
         'Config' => '0',
         'Env' => '0',
         'Module::Build' => '0.4004',
+	'Alien::Base::ModuleBuild' => '0',
     },
 
     test_requires => {

--- a/Build.PL
+++ b/Build.PL
@@ -9,8 +9,6 @@ use Carp;
 use Config;
 use Env qw/ALIEN_LIBUSBX_CFLAGS ALIEN_LIBUSBX_LIBS/;
 
-my $libusbx_version = '1.0.17';
-
 # Override the CFLAGS/LIBS settings
 sub alien_override($$$$) {
     my ($builder, $version, $cflags, $libs) = @_;
@@ -40,18 +38,11 @@ sub alien_override($$$$) {
     $builder->alien_provides_libs($libs);
 }
 
-# Mirror list: http://sourceforge.net/apps/trac/sourceforge/wiki/Mirrors
-my @mirrors = qw/aarnet dfn freefr garr heanet hivelocity internode
-jaist kaz kent master nchc netcologne softlayer-dal switch tenet ufpr
-waix/;
-
 my @alien_repos;
-foreach my $mirror (@mirrors) {
-    my $alien_repo = {
-        host => "$mirror.dl.sourceforge.net",
-    };
-    push @alien_repos, $alien_repo;
-}
+my $alien_repo = {
+    host => "https://github.com/libusb/libusb/releases",
+};
+push @alien_repos, $alien_repo;
 
 my $builder = Alien::Base::ModuleBuild->new(
     module_name => 'Alien::LibUSBx',
@@ -85,9 +76,8 @@ my $builder = Alien::Base::ModuleBuild->new(
 
     alien_name => 'libusb-1.0',
     alien_repository_default => {
-        protocol => 'http',
-        location => "/project/libusbx/releases/$libusbx_version/source",
-        exact_filename => "libusbx-$libusbx_version.tar.bz2",
+        protocol => 'https',
+        pattern  => qr/^.*\.tar\.bz2$/,
     },
     alien_repository => \@alien_repos,
 


### PR DESCRIPTION
Hello :smile: 

First thank you for this Alien module :)

I noticed a [failed build](https://github.com/thibaultduponchelle/aliens-ci/runs/656240194?check_suite_focus=true) concerning this module.

There are multiple reasons. First the missing Alien::Base::ModuleBuild in configure requires. Second the mirrors for libusbx are dead. 

I propose these fixes to make this module compile.
It includes https://github.com/henrikbrixandersen/Alien-LibUSBx/pull/1 and fixes https://rt.cpan.org/Ticket/Display.html?id=120639 

This is strictly technical, I have the feeling that there is a fork ([Alien::LibUSB](https://metacpan.org/pod/Alien::LibUSB)) that works well, install the same serie of libusb (1.0.*), is based on alienfile (as far as I know the current best practice for aliens) and should probably replace this module. I wanted to have your opinion, what is your vision for your module Alien::LibUSBx ?

I hope this PR will fit your criterias, at least it helps it to compile :+1: 

Thank you again.

/cc @plicease 

Best regards.

Thibault

